### PR TITLE
Added a /nextgame command

### DIFF
--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -167,9 +167,12 @@ def leave_handler(bot, update, user_data):
     if player is None or player.game is None:
         reply = "No game to leave!"
     else:
+        game = player.game
         player.leave_game(confirmed=True)
         reply = "Successfully left game!"
-
+        if game is not None and game.game_state==secret_hitler.GameStates.ACCEPT_PLAYERS and game.num_players==9:
+            for waiting_player in waiting_players_per_group[game.global_chat]:
+                bot.send_message(chat_id=waiting_player, text="A slot just opened up in [{}](t.me/{})!".format(bot.get_chat(chat_id=game.global_chat).title, game.global_chat))
     if player is None:
         bot.send_message(chat_id=update.message.chat.id, text=reply)
     else:

--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -51,6 +51,7 @@ def main():
     dispatcher.add_handler(CommandHandler('cancelgame', cancelgame_handler, pass_chat_data=True))
     dispatcher.add_handler(CommandHandler('leave', leave_handler, pass_user_data=True))
     dispatcher.add_handler(CommandHandler('restart', restart_handler))
+    dispatcher.add_handler(CommandHandler('nextgame', nextgame_handler))
 
     dispatcher.add_handler(
         CommandHandler(secret_hitler.Game.ACCEPTED_COMMANDS + tuple(COMMAND_ALIASES.keys()), game_command_handler,

--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -52,7 +52,7 @@ def main():
     dispatcher.add_handler(CommandHandler('leave', leave_handler, pass_user_data=True))
     dispatcher.add_handler(CommandHandler('restart', restart_handler))
     dispatcher.add_handler(CommandHandler('nextgame', nextgame_handler))
-
+    dispatcher.add_handler(CommandHandler('joingame', joingame_handler, pass_chat_data=True, pass_user_data=True))
     dispatcher.add_handler(
         CommandHandler(secret_hitler.Game.ACCEPTED_COMMANDS + tuple(COMMAND_ALIASES.keys()), game_command_handler,
                        pass_chat_data=True, pass_user_data=True))
@@ -118,6 +118,7 @@ def newgame_handler(bot, update, chat_data):
             bot.send_message(chat_id=waiting_player, text="A new game is starting in [{}](t.me/{})!".format(update.message.chat.title, chat_id))
         del waiting_players_per_group[chat_id]
 
+
 def nextgame_handler(bot, update, chat_data):
     """
     Add the issuing player to the current group’s waiting list if there is a game in progress.
@@ -148,6 +149,11 @@ def cancelgame_handler(bot, update, chat_data):
     else:
         bot.send_message(chat_id=chat_id, text="No game in progress here.")
 
+
+def joingame_handler(bot, update, chat_data, user_data):
+    if waiting_players_per_group[update.message.chat.id] is not None:
+        waiting_players_per_group[update.message.cnhat.id].remove(update.message.from_user.id)
+    game_command_handler(bot, update, chat_data, user_data)
 
 def leave_handler(bot, update, user_data):
     """

--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -110,11 +110,13 @@ def newgame_handler(bot, update, chat_data):
         bot.send_message(chat_id=chat_id,
                          text="Warning: game already in progress here. Reply '/newgame confirm' to confirm")
     else:
-        if game is not None:  # properly end that game
+        if game is not None:  # properly end any previous game
             game.set_game_state(secret_hitler.GameStates.GAME_OVER)
         chat_data["game_obj"] = secret_hitler.Game(chat_id)
         bot.send_message(chat_id=chat_id, text="Created game! /joingame to join, /startgame to start")
-
+        for waiting_player in waiting_players_per_group[chat_id]:
+            bot.send_message(chat_id=waiting_player, text="A new game is starting in [{}](t.me/{})!".format(update.message.chat.title, chat_id))
+        del waiting_players_per_group[chat_id]
 
 def nextgame_handler(bot, update, chat_data):
     """

--- a/bot_telegram.py
+++ b/bot_telegram.py
@@ -127,7 +127,7 @@ def nextgame_handler(bot, update, chat_data):
     if update.message.chat.type == "private":
         bot.send_message(chat_id=chat_id, text="You can’t wait for new games in private chat!")
     if game is not None and game.game_state == secret_hitler.GameStates.ACCEPT_PLAYERS and game.num_players<10 and update.message.text.find("confirm")==-1:
-        bot.send_message(chat_id=chat_id, text="You could still join the current game via /joingame. Type '/nextgame confirm' if you really want to wait.")
+        bot.send_message(chat_id=chat_id, text="You could still join the _current_ game via /joingame. Type '/nextgame confirm' if you really want to wait.")
     else:
         if chat_id not in waiting_players_per_group:
             waiting_players_per_group[chat_id]=[]

--- a/secret_hitler.py
+++ b/secret_hitler.py
@@ -889,7 +889,7 @@ class Game(object):
                 return p
         return None
 
-    ACCEPTED_COMMANDS = ("listplayers", "changename", "joingame", "startgame",
+    ACCEPTED_COMMANDS = ("listplayers", "changename", "startgame",
                          "boardstats", "deckstats", "anarchystats", "blame", "ja", "nein",
                          "nominate", "kill", "investigate", "enact", "discard", "whois",
                          "spectate", "unspectate", "logs")


### PR DESCRIPTION
Fix #42

Calling `/nextgame` in a group will add a player to a pool of waiting players.

When a new game is started, everyone in the pool is notified and removed from the pool.

When players enter the pool while a created-but-not-started game is full, they will be notified as soon as a slot opens, but remain in the pool regardless.

When a player joins a game, they are removed from the pool.

If there is a created-but-not-started game with free slots, players need to enter `/nextgame confirm` to enter the pool instead of the game.